### PR TITLE
Use MCR instead of DockerHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The deployment uses [Azure Building Blocks](https://github.com/mspnp/template-bu
 
 1. Create a directory named `DataFile` in the GitHub repo.
 
-1. Open a web browser and navigate to https://uofi.app.box.com/v/NYCtaxidata/folder/2332219935.
+1. Open a web browser and navigate to <https://uofi.app.box.com/v/NYCtaxidata/folder/2332219935>.
 
 1. Click the **Download** button on this page to download a zip file of all the taxi data for that year.
 
@@ -42,13 +42,13 @@ The deployment uses [Azure Building Blocks](https://github.com/mspnp/template-bu
 
 The directory structure should look like the following:
 
-```
-        /DataFile
-            /FOIL2013
-                trip_data_1.zip
-                trip_data_2.zip
-                trip_data_3.zip
-                ...
+```output
+/DataFile
+    /FOIL2013
+        trip_data_1.zip
+        trip_data_2.zip
+        trip_data_3.zip
+        ...
 ```
 
 ### Deploy the Azure resources
@@ -59,7 +59,7 @@ The directory structure should look like the following:
     export resourceGroup='[Resource group name]'
     export resourceLocation='[Location]'
     export cosmosDatabaseAccount='[Cosmos DB account name]'
-    export cosmosDatabase='[Cosmod DB database name]'
+    export cosmosDatabase='[Cosmos DB database name]'
     export cosmosDataBaseCollection='[Cosmos DB collection name]'
     export eventHubNamespace='[Event Hubs namespace name]'
 
@@ -75,7 +75,7 @@ The directory structure should look like the following:
       outputCosmosDatabaseCollection=$cosmosDataBaseCollection \
       query='@./azure/average-tip-per-mile-pipeline.asaql'
 
-    # Create a database 
+    # Create a database
     az cosmosdb database create --name $cosmosDatabaseAccount \
         --db-name $cosmosDatabase --resource-group $resourceGroup
 
@@ -117,7 +117,7 @@ The directory structure should look like the following:
 
 3. Update the values in the file `main.env` as follows:
 
-    ```
+    ```output
     RIDE_EVENT_HUB=[Connection string for taxi-ride event hub]
     FARE_EVENT_HUB=[Connection string for taxi-fare event hub]
     RIDE_DATA_FILE_PATH=/DataFile/FOIL2013
@@ -145,7 +145,7 @@ The directory structure should look like the following:
 
 The output should look like the following:
 
-```
+```output
 Created 10000 records for TaxiFare
 Created 10000 records for TaxiRide
 Created 20000 records for TaxiFare
@@ -154,4 +154,4 @@ Created 30000 records for TaxiFare
 ...
 ```
 
-Let the program run for at least 5 minutes, which is the window defined in the Stream Analytics query. To verify the Stream Analytics job is running correctly, open the Azure portal and navigate to the Cosmos DB database. Open the **Data Explorer** blade and view the documents. 
+Let the program run for at least 5 minutes, which is the window defined in the Stream Analytics query. To verify the Stream Analytics job is running correctly, open the Azure portal and navigate to the Cosmos DB database. Open the **Data Explorer** blade and view the documents.

--- a/onprem/Dockerfile
+++ b/onprem/Dockerfile
@@ -1,13 +1,13 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 AS build
 RUN apt-get update
 RUN apt-get install -y git
 RUN git clone --recursive https://github.com/mspnp/azure-stream-analytics-data-pipeline.git  &&  cd azure-stream-analytics-data-pipeline && git fetch && git checkout master
 WORKDIR azure-stream-analytics-data-pipeline/onprem/DataLoader
-RUN dotnet build
+RUN dotnet build -c Release
 RUN dotnet publish -f netcoreapp2.0 -c Release
 
 
-FROM microsoft/dotnet:2.1-runtime AS runtime
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1 AS runtime
 WORKDIR DataLoader
 COPY --from=build azure-stream-analytics-data-pipeline/onprem/DataLoader/bin/Release/netcoreapp2.0/publish .
 ENTRYPOINT ["dotnet" , "taxi.dll"]


### PR DESCRIPTION
* Move two DockerHub references to MCR
* Optimize the build by doing a release build so the publish doesn't have to do it again
* Minor formatting/typo changes in the README